### PR TITLE
SRAM size modification, Add asm file

### DIFF
--- a/asm/sim.py
+++ b/asm/sim.py
@@ -8,6 +8,9 @@ import jax.numpy as jnp
 
 is_debug = False
 
+SRAM_WIDTH = 128
+SRAM_DEPTH = 4096
+
 REG_ZERO = 0
 REG_A = 1
 REG_B = 2
@@ -149,7 +152,7 @@ def save(data, filename):
 
 
 class Host:
-    def __init__(self, mem_size=512 * 1024, npus=4, out='stdout'):
+    def __init__(self, mem_size=SRAM_WIDTH * SRAM_DEPTH, npus=4, out='stdout'):
         self.kernel = None
         self.data = {}
         self.updated = {}
@@ -274,7 +277,7 @@ class Host:
 
 
 class NPU(threading.Thread):
-    def __init__(self, id, mem_size=512 * 1024, out='stdout'):
+    def __init__(self, id, mem_size=SRAM_WIDTH * SRAM_DEPTH, out='stdout'):
         super().__init__()
 
         self.id = id

--- a/examples/with-load-store-vadd.bf16.asm
+++ b/examples/with-load-store-vadd.bf16.asm
@@ -1,0 +1,58 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Save data to files')
+    save(host.data[0x200000], 'vadd.ls.200000.data')
+    save(host.data[0x201000], 'vadd.ls.201000.data')
+    save(host.data[0x202000], 'vadd.ls.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A + B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# Load 0x200000 into A
+seti %a 0x20  # (128) / 4
+seti %b 0x4000  # 0x200000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# Load 0x201000 into B
+seti %a 0x420  # (128 + 4096) / 4
+seti %b 0x4020  # 0x201000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# vadd.bf16 C = A + B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vadd.bf16 %c %a %b %d
+
+# Store C to 0x202000
+seti %a 0x4040  # 0x202000 / 128
+seti %b 0x820  # (128 + 4096 + 4096) / 4
+seti %c 1024  # (2048 * 2) / 4
+store %a %b %c
+
+# Interrupt to CPU
+return

--- a/examples/with-load-store-vdiv.bf16.asm
+++ b/examples/with-load-store-vdiv.bf16.asm
@@ -1,0 +1,58 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([(v + 1) * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([(v + 1) * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Save data to files')
+    save(host.data[0x200000], 'vdiv.ls.200000.data')
+    save(host.data[0x201000], 'vdiv.ls.201000.data')
+    save(host.data[0x202000], 'vdiv.ls.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([(v + 1) * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([(v + 1) * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A / B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# Load 0x200000 into A
+seti %a 0x20  # (128) / 4
+seti %b 0x4000  # 0x200000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# Load 0x201000 into B
+seti %a 0x420  # (128 + 4096) / 4
+seti %b 0x4020  # 0x201000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# vdiv.bf16 C = A / B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vdiv.bf16 %c %a %b %d
+
+# Store C to 0x202000
+seti %a 0x4040  # 0x202000 / 128
+seti %b 0x820  # (128 + 4096 + 4096) / 4
+seti %c 1024  # (2048 * 2) / 4
+store %a %b %c
+
+# Interrupt to CPU
+return

--- a/examples/with-load-store-vmul.bf16.asm
+++ b/examples/with-load-store-vmul.bf16.asm
@@ -1,0 +1,58 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Save data to files')
+    save(host.data[0x200000], 'vmul.ls.200000.data')
+    save(host.data[0x201000], 'vmul.ls.201000.data')
+    save(host.data[0x202000], 'vmul.ls.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A * B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# Load 0x200000 into A
+seti %a 0x20  # (128) / 4
+seti %b 0x4000  # 0x200000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# Load 0x201000 into B
+seti %a 0x420  # (128 + 4096) / 4
+seti %b 0x4020  # 0x201000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# vmul.bf16 C = A * B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vmul.bf16 %c %a %b %d
+
+# Store C to 0x202000
+seti %a 0x4040  # 0x202000 / 128
+seti %b 0x820  # (128 + 4096 + 4096) / 4
+seti %c 1024  # (2048 * 2) / 4
+store %a %b %c
+
+# Interrupt to CPU
+return

--- a/examples/with-load-store-vsub.bf16.asm
+++ b/examples/with-load-store-vsub.bf16.asm
@@ -1,0 +1,58 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Save data to files')
+    save(host.data[0x200000], 'vsub.ls.200000.data')
+    save(host.data[0x201000], 'vsub.ls.201000.data')
+    save(host.data[0x202000], 'vsub.ls.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A - B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# Load 0x200000 into A
+seti %a 0x20  # (128) / 4
+seti %b 0x4000  # 0x200000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# Load 0x201000 into B
+seti %a 0x420  # (128 + 4096) / 4
+seti %b 0x4020  # 0x201000 / 128
+seti %c 1024  # (2048 * 2) / 4
+load %a %b %c
+
+# vsub.bf16 C = A - B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vsub.bf16 %c %a %b %d
+
+# Store C to 0x202000
+seti %a 0x4040  # 0x202000 / 128
+seti %b 0x820  # (128 + 4096 + 4096) / 4
+seti %c 1024  # (2048 * 2) / 4
+store %a %b %c
+
+# Interrupt to CPU
+return

--- a/examples/without-load-store-vadd.bf16.asm
+++ b/examples/without-load-store-vadd.bf16.asm
@@ -1,0 +1,45 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+    host.store(0, 0x80, 0x200000, 2048 * 2)
+    host.store(0, 0x1080, 0x201000, 2048 * 2)
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Load data into host memory')
+    host.load(0, 0x202000, 0x2080, 2048 * 2)
+
+    print('# Save data to files')
+    save(host.data[0x200000], 'vadd.200000.data')
+    save(host.data[0x201000], 'vadd.201000.data')
+    save(host.data[0x202000], 'vadd.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A + B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# vadd.bf16 C = A + B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vadd.bf16 %c %a %b %d
+
+# Interrupt to CPU
+return

--- a/examples/without-load-store-vdiv.bf16.asm
+++ b/examples/without-load-store-vdiv.bf16.asm
@@ -1,0 +1,45 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([(v + 1) * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([(v + 1) * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+    host.store(0, 0x80, 0x200000, 2048 * 2)
+    host.store(0, 0x1080, 0x201000, 2048 * 2)
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Load data into host memory')
+    host.load(0, 0x202000, 0x2080, 2048 * 2)
+
+    print('# Save data to files')
+    save(host.data[0x200000], 'vdiv.200000.data')
+    save(host.data[0x201000], 'vdiv.201000.data')
+    save(host.data[0x202000], 'vdiv.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([(v + 1) * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([(v + 1) * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A / B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# vdiv.bf16 C = A / B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vdiv.bf16 %c %a %b %d
+
+# Interrupt to CPU
+return

--- a/examples/without-load-store-vmul.bf16.asm
+++ b/examples/without-load-store-vmul.bf16.asm
@@ -1,0 +1,45 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+    host.store(0, 0x80, 0x200000, 2048 * 2)
+    host.store(0, 0x1080, 0x201000, 2048 * 2)
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Load data into host memory')
+    host.load(0, 0x202000, 0x2080, 2048 * 2)
+
+    print('# Save data to files')
+    save(host.data[0x200000], 'vmul.200000.data')
+    save(host.data[0x201000], 'vmul.201000.data')
+    save(host.data[0x202000], 'vmul.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A * B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# vmul.bf16 C = A * B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vmul.bf16 %c %a %b %d
+
+# Interrupt to CPU
+return

--- a/examples/without-load-store-vsub.bf16.asm
+++ b/examples/without-load-store-vsub.bf16.asm
@@ -1,0 +1,45 @@
+### script
+def init(host):
+    host.data[0x200000] = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x201000] = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16).tobytes()
+    host.data[0x202000] = zeros(2048 * 2)
+
+    host.store(0, 0x00, 0x00, len(host.kernel))  # 0x00 means kernel
+    host.store(0, 0x80, 0x200000, 2048 * 2)
+    host.store(0, 0x1080, 0x201000, 2048 * 2)
+
+def run(host):
+    host.exec(0)
+
+def finalize(host):
+    print('# Load data into host memory')
+    host.load(0, 0x202000, 0x2080, 2048 * 2)
+
+    print('# Save data to files')
+    save(host.data[0x200000], 'vsub.200000.data')
+    save(host.data[0x201000], 'vsub.201000.data')
+    save(host.data[0x202000], 'vsub.202000.data')
+
+    print('# Compare result')
+    result = jnp.frombuffer(host.data[0x202000], dtype=jnp.bfloat16)
+
+    A = jnp.array([v * 1.1 for v in range(2048)], dtype=jnp.bfloat16)
+    B = jnp.array([v * 0.1 for v in range(2048)], dtype=jnp.bfloat16)
+
+    dump_compare(result, A - B)
+###
+
+# kernel is stored at 0
+# Assume the kernel size is 128 or less.
+# The total data size is set to 2048 of the maximum bfloat16 type(2 Bytes) variable size.
+
+# vsub.bf16 C = A - B
+seti %a 0x20  # 128 / 4  # A is stored at 128
+seti %b 0x420  # (128 + 4096) / 4  # B is stored at 128 + 4096
+seti %c 0x820  # (128 + 4096 *2) / 4  # C is stored at 128 + 4096 + 4096
+seti %d 2048  # count is 2048
+
+vsub.bf16 %c %a %b %d
+
+# Interrupt to CPU
+return


### PR DESCRIPTION
asm/sim.py : 메모리 크기 변경 512 * 1024 --> 128 * 4096
examples : kernel 이미지에 load/store 기능 유무에 따른 asm 파일 추가
load/store 기능 유:
        new file:   examples/with-load-store-vadd.bf16.asm
        new file:   examples/with-load-store-vdiv.bf16.asm
        new file:   examples/with-load-store-vmul.bf16.asm
        new file:   examples/with-load-store-vsub.bf16.asm 
load/store 기능 무
        new file:   examples/without-load-store-vadd.bf16.asm
        new file:   examples/without-load-store-vdiv.bf16.asm
        new file:   examples/without-load-store-vmul.bf16.asm
        new file:   examples/without-load-store-vsub.bf16.asm