### PR TITLE
Bug fixes in LoadStoreController and DMAPathController

### DIFF
--- a/src/resources/vsrc/DMAPathController.v
+++ b/src/resources/vsrc/DMAPathController.v
@@ -171,6 +171,7 @@ wire fpu_write_rdy;
 wire [127:0] fpu_write_data;
 wire fpu_write_vld;
 reg[15:0] fpu_write_length;
+reg[7:0] msg_form;
 reg[15:0] fpu_write_cnt;
 wire [3:0] dma_req;
 
@@ -398,6 +399,7 @@ always@(posedge fpu_clk or posedge reset) begin
 		fpu_resp <= 1'b0;
 		fpu_write_cnt <= 16'd0;
 		fpu_write_length <= 16'd0;
+		msg_form <= 8'd0;
 		fpu_resp_done <= 1'b0;
 		dpc_rdy <= 1'b0;
 
@@ -423,13 +425,19 @@ always@(posedge fpu_clk or posedge reset) begin
 				if(fpu_write_vld&&fpu_write_rdy)begin
 					fpu_write_cnt <= fpu_write_cnt + 1;
 					fpu_write_length <= fpu_write_data[71:56];
+					msg_form <= fpu_write_data[79:72];
 					fpu_resp <= 1'b0;
 					fwdcon <= fwdc_s1;
 				end
 				
 			end
 			fwdc_s1 : begin
-				if(fpu_write_cnt >= fpu_write_length) begin
+				if(msg_form==8'h01) begin
+					dpc_rdy <= 1'b0;
+					fwdcon <= fwdc_end;
+					fpu_resp <= 1'b0;
+				end
+				else if(fpu_write_cnt >= fpu_write_length) begin
 					dpc_rdy <= 1'b0;
 					fwdcon <= fwdc_end;
 					fpu_resp <= 1'b0;

--- a/src/resources/vsrc/loadStoreController.v
+++ b/src/resources/vsrc/loadStoreController.v
@@ -147,7 +147,7 @@ always@(posedge clk or posedge rst) begin
       end
       dpc_wr_data0 : begin
         wr_en <= 1'b1;
-        dma_write_data <= {48'd0,8'h03,core_transferLength,core_hostAddr,core_localAddr};
+        dma_write_data <= {48'd0,8'h03,core_transferLength,core_hostAddr,2'b00,core_localAddr};
         if(dma_write_ready) begin
           dpcon <= dpc_wr_data1;
         end
@@ -177,7 +177,7 @@ always@(posedge clk or posedge rst) begin
       dpc_rd_data : begin
         if(dma_write_ready) begin
           rd_en <= 1'b1;
-          dma_write_data <= {48'd0,8'h01,core_transferLength,core_hostAddr,core_localAddr};
+          dma_write_data <= {48'd0,8'h01,core_transferLength,core_hostAddr,2'b00,core_localAddr};
           dpcon <= dpc_end;
         end
       end

--- a/src/testbench/test_core.v
+++ b/src/testbench/test_core.v
@@ -144,7 +144,9 @@ initial begin
 end
 
 //always @(posedge clk) if(dma_req) dma_ready <= 1; else dma_ready <= 0;
-  
+
+assign _DMAEngineDef_io_rcc_ready = 1'd1;
+
 NPUCore uut0 (
     .clk(clk),
     .rstn(rstn),


### PR DESCRIPTION
Fixed the problem of stopping while reading while waiting for length, and fixed the part that did not match the message format due to the difference in the width of the local address coming from the fpu.